### PR TITLE
Fixing Prod Role missing issue

### DIFF
--- a/GitHub-Organizations-Secret/resource-role-prod.yaml
+++ b/GitHub-Organizations-Secret/resource-role-prod.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/GitHub-Repositories-Secret/resource-role-prod.yaml
+++ b/GitHub-Repositories-Secret/resource-role-prod.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn


### PR DESCRIPTION
Fixing Prod Missing Role for GitHubRepositoriesSecretand GitHubOrganizationsSecret 

Testing: 
Local Testing is successful 

Prod : 
GitHub-Repositories-Secret : 

describe-type-registration
1152 | {
1153 | "ProgressStatus": "COMPLETE",
1154 | "Description": "Deployment is currently in DEPLOY_STAGE of status COMPLETED - [WARNING] Readiness Review SKIPPED:",
1155 | "TypeArn": "arn:aws:cloudformation:us-east-1:123456789012:type/resource/GitHub-Repositories-Secret",
1156 | "TypeVersionArn": "arn:aws:cloudformation:us-east-1:123456789012:type/resource/GitHub-Repositories-Secret/00000003"
1157 | }





GitHub-Organizations-Secret : 

describe-type-registration
1155 | {
1156 | "ProgressStatus": "COMPLETE",
1157 | "Description": "Deployment is currently in DEPLOY_STAGE of status COMPLETED - [WARNING] Readiness Review SKIPPED:",
1158 | "TypeArn": "arn:aws:cloudformation:us-east-1:123456789012:type/resource/GitHub-Organizations-Secret",
1159 | "TypeVersionArn": "arn:aws:cloudformation:us-east-1:123456789012:type/resource/GitHub-Organizations-Secret/00000003"
1160

<br class="Apple-interchange-newline">