### PR TITLE
fix for being unable to rename github repo

### DIFF
--- a/GitHub-Repositories-Repository/docs/README.md
+++ b/GitHub-Repositories-Repository/docs/README.md
@@ -301,6 +301,10 @@ The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of
 
 For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
 
+#### Id
+
+The ID of the repository.
+
 #### Owner
 
 ID of the repository owner.

--- a/GitHub-Repositories-Repository/github-repositories-repository.json
+++ b/GitHub-Repositories-Repository/github-repositories-repository.json
@@ -100,6 +100,10 @@
     ]
   },
   "properties": {
+    "Id": {
+      "description": "The ID of the repository.",
+      "type": "number"
+    },
     "Organization": {
       "description": "The organization name. The name is not case sensitive. If not specified, then the managed repository will be within the currently logged-in user account.",
       "type": "string"
@@ -245,6 +249,7 @@
     "Name"
   ],
   "readOnlyProperties": [
+    "/properties/Id",
     "/properties/Owner",
     "/properties/HtmlUrl",
     "/properties/GitUrl",
@@ -273,8 +278,8 @@
     "/properties/SecurityAndAnalysis"
   ],
   "primaryIdentifier": [
-    "/properties/Owner",
-    "/properties/Name"
+    "/properties/Id",
+    "/properties/Owner"
   ],
   "handlers": {
     "create": {

--- a/GitHub-Repositories-Repository/src/models.ts
+++ b/GitHub-Repositories-Repository/src/models.ts
@@ -9,10 +9,19 @@ export class ResourceModel extends BaseModel {
     public static readonly TYPE_NAME: string = 'GitHub::Repositories::Repository';
 
     @Exclude()
-    protected readonly IDENTIFIER_KEY_OWNER: string = '/properties/Owner';
+    protected readonly IDENTIFIER_KEY_ID: string = '/properties/Id';
     @Exclude()
-    protected readonly IDENTIFIER_KEY_NAME: string = '/properties/Name';
+    protected readonly IDENTIFIER_KEY_OWNER: string = '/properties/Owner';
 
+    @Expose({ name: 'Id' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(Number, 'id', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    id?: Optional<number>;
     @Expose({ name: 'Organization' })
     @Transform(
         (value: any, obj: any) =>
@@ -290,12 +299,12 @@ export class ResourceModel extends BaseModel {
     @Exclude()
     public getPrimaryIdentifier(): Dict {
         const identifier: Dict = {};
-        if (this.owner != null) {
-            identifier[this.IDENTIFIER_KEY_OWNER] = this.owner;
+        if (this.id != null) {
+            identifier[this.IDENTIFIER_KEY_ID] = this.id;
         }
 
-        if (this.name != null) {
-            identifier[this.IDENTIFIER_KEY_NAME] = this.name;
+        if (this.owner != null) {
+            identifier[this.IDENTIFIER_KEY_OWNER] = this.owner;
         }
 
         // only return the identifier if it can be used, i.e. if all components are present


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Notes.

* The `Name` property was in the list of `createOnlyProperties`. Removed that so it can be used in update operation
* The default api user path using the `owner` and `name` properties. This has caused issues when trying to update since the name was primaryIdentifier and therefore even though it was specified in update input, it used original value. If name was removed from primaryIdentifier list, it would be unable to call the api correctly for GET handler. 
* Fortunately, there is an alternative that allows us to call the api with the `ID` instead of `owner` and `name`: see here for more reference: https://github.com/piotrmurach/github/issues/282
* Therefore, adding the ID as read only parameter and making that ID a primaryIdentifier,  then calling the alternative API makes this work as expected, allowing for renaming
* Since we use octokit endpoints, had to use ts-ignore, as the alternative api method is not part of endpoints interface in octokit - however it works as expected 